### PR TITLE
Remove explicit KtLint version number

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,6 @@ subprojects {
 
     ktlint {
         debug.set(false)
-        version.set(Versions.KTLINT)
         verbose.set(true)
         android.set(false)
         outputToConsole.set(true)

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,6 +1,5 @@
 object Versions {
     const val JUNIT = "4.13.2"
-    const val KTLINT = "0.41.0"
 }
 
 object BuildPluginsVersion {

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -25,7 +25,6 @@ allprojects {
 
     ktlint {
         debug.set(false)
-        version.set(Versions.KTLINT)
         verbose.set(true)
         android.set(false)
         outputToConsole.set(true)

--- a/plugin-build/buildSrc/src/main/java/Dependencies.kt
+++ b/plugin-build/buildSrc/src/main/java/Dependencies.kt
@@ -1,6 +1,5 @@
 object Versions {
     const val JUNIT = "4.13.2"
-    const val KTLINT = "0.41.0"
 }
 
 object BuildPluginsVersion {


### PR DESCRIPTION
## 🚀 Description
Removing explicit KtLint version number as it's not needed anymore. ktlint-gradle is providing it.