### PR TITLE
Add mavenCoordinates to pluginBundle

### DIFF
--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -38,6 +38,12 @@ pluginBundle {
             displayName = PluginBundle.DISPLAY_NAME
         }
     }
+
+    mavenCoordinates {
+        groupId = PluginCoordinates.GROUP
+        artifactId = PluginCoordinates.ID
+        version = PluginCoordinates.VERSION
+    }
 }
 
 tasks.create("setupPluginUploadFromEnvironment") {


### PR DESCRIPTION
Thank you for the useful plugin template.

However, when I tried to publish https://github.com/sya-ri/minecraft-server-gradle-plugin to the Gradle Plugin Portal, I was pointed out like this.

> The plugin JAR coordinates start with "gradle.plugin" which we are aiming at no longer allowing. Please follow the full example at [plugins.gradle.org/docs/publish-plugin](https://plugins.gradle.org/docs/publish-plugin) to get rid of it. You will need to add a mavenCoordinates block into the pluginBundle block of the build file.

I just added this commit https://github.com/sya-ri/minecraft-server-gradle-plugin/commit/ac341f4b48576834f958897e2a610436fb9d37d3 and it was approved.

Thank you <3