### PR TITLE
Remove deprecated jcenter repository

### DIFF
--- a/plugin-build/buildSrc/build.gradle.kts
+++ b/plugin-build/buildSrc/build.gradle.kts
@@ -2,5 +2,5 @@ plugins {
     `kotlin-dsl`
 }
 repositories {
-    jcenter()
+    mavenCentral()
 }


### PR DESCRIPTION
## 🚀 Description
Remove deprecated jcenter repository

## 📄 Motivation and Context
Jcenter has been deprecated since 2021. While this PR is small and negligible for common cases, because this repository is a Gradle plugin template PR with hundreds of stars, I think putting up a PR is still worthy.

## 🧪 How Has This Been Tested?
Not tested. But the compilation works.

## 📦 Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.