### PR TITLE
Handle build script deprecations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ subprojects {
     }
 
     detekt {
-        config = rootProject.files("config/detekt/detekt.yml")
+        config.setFrom(rootProject.files("config/detekt/detekt.yml"))
     }
 }
 
@@ -48,7 +48,7 @@ tasks.withType<DependencyUpdatesTask> {
 fun String.isNonStable() = "^[0-9,.v-]+(-r)?$".toRegex().matches(this).not()
 
 tasks.register("clean", Delete::class.java) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }
 
 tasks.register("reformatAll") {

--- a/plugin-build/build.gradle.kts
+++ b/plugin-build/build.gradle.kts
@@ -31,7 +31,7 @@ allprojects {
     }
 
     detekt {
-        config = rootProject.files("../config/detekt/detekt.yml")
+        config.setFrom(rootProject.files("../config/detekt/detekt.yml"))
     }
 }
 
@@ -43,7 +43,7 @@ tasks.withType<Detekt>().configureEach {
 }
 
 tasks.register("clean", Delete::class.java) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }
 
 tasks.wrapper {


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Uses config.setFrom to set detekt config file and migrates the 'clean' task to use rootProject.layout.buildDirectory.

## 📄 Motivation and Context
Remove deprecation warnings when cloning this repo for the first time.

## 🧪 How Has This Been Tested?
By running the relevant Gradle tasks.

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.