### PR TITLE
build: migrate gradle-enterprise to develocity

### DIFF
--- a/plugin-build/settings.gradle.kts
+++ b/plugin-build/settings.gradle.kts
@@ -19,16 +19,16 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    `gradle-enterprise`
+	id("com.gradle.develocity") version "3.17.4"
 }
 
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-        publishAlwaysIf(System.getenv("GITHUB_ACTIONS") == "true")
-        publishOnFailure()
-    }
+develocity {
+	buildScan.termsOfUseUrl = "https://gradle.com/terms-of-service"
+	buildScan.termsOfUseAgree = "yes"
+	buildScan.publishing.onlyIf {
+		System.getenv("GITHUB_ACTIONS") == "true" &&
+				it.buildResult.failures.isNotEmpty()
+	}
 }
 
 rootProject.name = ("com.ncorti.kotlin.gradle.template")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,16 +13,16 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    `gradle-enterprise`
+	id("com.gradle.develocity") version "3.17.4"
 }
 
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-        publishAlwaysIf(System.getenv("GITHUB_ACTIONS") == "true")
-        publishOnFailure()
-    }
+develocity {
+	buildScan.termsOfUseUrl = "https://gradle.com/terms-of-service"
+	buildScan.termsOfUseAgree = "yes"
+	buildScan.publishing.onlyIf {
+		System.getenv("GITHUB_ACTIONS") == "true" &&
+				it.buildResult.failures.isNotEmpty()
+	}
 }
 
 rootProject.name = "kotlin-gradle-plugin-template"


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
<!-- Describe your changes in detail -->

To remove following warning, migrate to develocity.

WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. Run with '-Ddevelocity.deprecation.captureOrigin=true' to see where the deprecated functionality is being used. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.
- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"
- The deprecated "gradleEnterprise.buildScan.termsOfServiceAgree" API has been replaced by "develocity.buildScan.termsOfUseAgree"
- The deprecated "gradleEnterprise.buildScan.publishAlwaysIf(condition)" API has been replaced by "develocity.buildScan.publishing.onlyIf { condition }"
- The deprecated "gradleEnterprise.buildScan.publishOnFailure" API has been replaced by "develocity.buildScan.publishing.onlyIf { !it.buildResult.failures.empty }"
- The "com.gradle.enterprise" plugin has been replaced by "com.gradle.develocity"


## 📄 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.