### PR TITLE
Use Detekt with type resolution

### DIFF
--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -33,7 +33,7 @@ gradlePlugin {
             description = property("DESCRIPTION").toString()
             displayName = property("DISPLAY_NAME").toString()
             // Note: tags cannot include "plugin" or "gradle" when publishing
-            tags.set(listOf("plugin", "gradle", "sample", "template"))
+            tags.set(listOf("sample", "template"))
         }
     }
 }

--- a/plugin-build/plugin/build.gradle.kts
+++ b/plugin-build/plugin/build.gradle.kts
@@ -32,6 +32,7 @@ gradlePlugin {
             version = property("VERSION").toString()
             description = property("DESCRIPTION").toString()
             displayName = property("DISPLAY_NAME").toString()
+            // Note: tags cannot include "plugin" or "gradle" when publishing
             tags.set(listOf("plugin", "gradle", "sample", "template"))
         }
     }
@@ -40,6 +41,15 @@ gradlePlugin {
 gradlePlugin {
     website.set(property("WEBSITE").toString())
     vcsUrl.set(property("VCS_URL").toString())
+}
+
+// Use Detekt with type resolution for check
+tasks.named("check").configure {
+    this.setDependsOn(
+        this.dependsOn.filterNot {
+            it is TaskProvider<*> && it.name == "detekt"
+        } + tasks.named("detektMain"),
+    )
 }
 
 tasks.create("setupPluginUploadFromEnvironment") {

--- a/plugin-build/plugin/src/main/java/com/ncorti/kotlin/gradle/template/plugin/TemplateExampleTask.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/kotlin/gradle/template/plugin/TemplateExampleTask.kt
@@ -31,7 +31,7 @@ abstract class TemplateExampleTask : DefaultTask() {
 
     @TaskAction
     fun sampleAction() {
-        val prettyTag = tag.orNull?.let { "[$it]" } ?: ""
+        val prettyTag = tag.orNull?.let { "[$it]" }.orEmpty()
 
         logger.lifecycle("$prettyTag message is: ${message.orNull}")
         logger.lifecycle("$prettyTag tag is: ${tag.orNull}")

--- a/plugin-build/plugin/src/main/java/com/ncorti/kotlin/gradle/template/plugin/TemplatePlugin.kt
+++ b/plugin-build/plugin/src/main/java/com/ncorti/kotlin/gradle/template/plugin/TemplatePlugin.kt
@@ -6,6 +6,7 @@ import org.gradle.api.Project
 const val EXTENSION_NAME = "templateExampleConfig"
 const val TASK_NAME = "templateExample"
 
+@Suppress("UnnecessaryAbstractClass")
 abstract class TemplatePlugin : Plugin<Project> {
     override fun apply(project: Project) {
         // Add the 'template' extension object


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Replaces default detekt task with detektMain (type resolution) when running `check`

## 📄 Motivation and Context
Enables the Detekt rules that require type resolution to run by default

## 🧪 How Has This Been Tested?
Tested by running `preMerge` and introducing errors that require TR to identify

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.